### PR TITLE
Fix Windows smartquotes and emdashes (non-ascii)

### DIFF
--- a/scripts/powershell/list_local_admins_remote_hosts.ps1
+++ b/scripts/powershell/list_local_admins_remote_hosts.ps1
@@ -1,9 +1,9 @@
 function get-localadmin {  
     param ($strcomputer)  
-    $admins = Gwmi win32_groupuser –computer $strcomputer   
-    $admins = $admins |? {$_.groupcomponent –like '*"Administrators"'}  
+    $admins = Gwmi win32_groupuser -computer $strcomputer   
+    $admins = $admins |? {$_.groupcomponent -like '*"Administrators"'}  
     $admins |% {  
-        $_.partcomponent –match “.+Domain\=(.+)\,Name\=(.+)$” > $nul  
-        $matches[1].trim('"') + “\” + $matches[2].trim('"')  
+        $_.partcomponent -match ".+Domain\=(.+)\,Name\=(.+)$" > $nul  
+        $matches[1].trim('"') + "\" + $matches[2].trim('"')  
     }
 }


### PR DESCRIPTION
I'm not sure if this makes a difference to PS, but I find smartquotes irritating 
and a source of subtle bugs. The emdashes are another Windows-1252 thing.

Reference:  https://en.wikipedia.org/wiki/Windows-1252
